### PR TITLE
Skip going deeper when an element is found using getChildrenByType

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nanny",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "Utils to manage your React Children; find and filter children by type or custom function, enforce child content, and more!",
   "main": "lib/es5/index.js",
   "module": "lib/es6/index.js",

--- a/src/getChildrenByType/index.deep.test.js
+++ b/src/getChildrenByType/index.deep.test.js
@@ -4,12 +4,12 @@ const React = require('react');
 const { getChildrenByTypeDeep } = require('../../dist/lib/es5/index');
 
 const children = [
-  { 
-    props: { 
+  {
+    props: {
       __TYPE: 'div',
       children: [
-        { 
-          props: { 
+        {
+          props: {
             __TYPE: 'div',
             children: [
               { props: { __TYPE: 'CustomComponent', active: true, children: 'Deep child active' }},
@@ -24,6 +24,13 @@ const children = [
   },
   { props: { __TYPE: 'CustomComponent', active: false, children: 'Outer child' }},
   { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
+  {
+    props: {
+      __TYPE: 'CustomComponentGroup', active: true, children: [
+        {props: {__TYPE: 'CustomComponent', active: true, children: 'Outer child active in group'}},
+      ],
+    },
+  },
   { type: 'span' },
   { type: 'div' },
 ];
@@ -35,6 +42,7 @@ describe('getChildrenByTypeDeep', () => {
       { props: { __TYPE: 'CustomComponent', active: true, children: 'Deep child active' }},
       { props: { __TYPE: 'CustomComponent', active: false, children: 'Outer child' }},
       { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
+      { props: {__TYPE: 'CustomComponent', active: true, children: 'Outer child active in group'}},
     ]);
   });
 
@@ -43,8 +51,41 @@ describe('getChildrenByTypeDeep', () => {
       { props: { __TYPE: 'CustomComponent', active: true, children: 'Deep child active' }},
       { props: { __TYPE: 'CustomComponent', active: false, children: 'Outer child' }},
       { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
+      { props: {__TYPE: 'CustomComponent', active: true, children: 'Outer child active in group' }},
     ]);
   });
+
+  test('Deep Custom Component Mixed', () => {
+    expect(getChildrenByTypeDeep(children, ['CustomComponent', 'CustomComponentGroup'])).toStrictEqual([
+      { props: { __TYPE: 'CustomComponent', active: true, children: 'Deep child active' }},
+      { props: { __TYPE: 'CustomComponent', active: false, children: 'Outer child' }},
+      { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
+      {
+        props: {
+          __TYPE: 'CustomComponentGroup', active: true, children: [
+            {props: {__TYPE: 'CustomComponent', active: true, children: 'Outer child active in group'}},
+          ],
+        },
+      },
+      { props: {__TYPE: 'CustomComponent', active: true, children: 'Outer child active in group'}},
+    ]);
+  });
+
+    test('Deep Custom Component Mixed Skip', () => {
+        expect(getChildrenByTypeDeep(children, ['CustomComponent', 'CustomComponentGroup'], {skipWhenFound: true})).toStrictEqual([
+            { props: { __TYPE: 'CustomComponent', active: true, children: 'Deep child active' }},
+            { props: { __TYPE: 'CustomComponent', active: false, children: 'Outer child' }},
+            { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
+            {
+                props: {
+                    __TYPE: 'CustomComponentGroup', active: true, children: [
+                        {props: {__TYPE: 'CustomComponent', active: true, children: 'Outer child active in group'}},
+                    ],
+                },
+            },
+        ]);
+    });
+
 
   test('Standard Html (JSX) Components', () => {
     expect(getChildrenByTypeDeep(children, ['span'])).toStrictEqual([
@@ -55,12 +96,13 @@ describe('getChildrenByTypeDeep', () => {
   });
 
   test('Mixed', () => {
-    expect(getChildrenByTypeDeep(children, ['span', 'CustomComponent'])).toStrictEqual([      
+    expect(getChildrenByTypeDeep(children, ['span', 'CustomComponent'])).toStrictEqual([
       { props: { __TYPE: 'CustomComponent', active: true, children: 'Deep child active' }},
       { type: 'span', props: { children: 'Deep span' }},
       { type: 'span', props: { children: 'Outer span', hello: 'world' }},
       { props: { __TYPE: 'CustomComponent', active: false, children: 'Outer child' }},
       { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
+      {props: {__TYPE: 'CustomComponent', active: true, children: 'Outer child active in group'}},
       { type: 'span' },
     ]);
   });

--- a/src/getChildrenByType/index.ts
+++ b/src/getChildrenByType/index.ts
@@ -48,13 +48,14 @@ export const getChildrenByType = <T=React.ReactNode, TC=unknown>(children: T, ty
  * @template TC
  * @param {T} children - JSX children
  * @param {TC | TC[]} types - Types of children to match
- * @param {GetChildrenByTypeConfig} [{ customTypeKey: '__TYPE' }] - The configuration params
+ * @param {GetChildrenByTypeConfig} [{ customTypeKey: '__TYPE', skipWhenFound: false }] - The configuration params
  * @returns {T[]} - Array of matching children
  * @docgen_types
  * // The configuration type for the util:
  * //   customTypeKey?: string = '__TYPE' - The custom component prop key to check the type
+ * //   skipWhenFound?: boolean = false - Will stop the depth search when something was found
  * 
- * export type GetChildrenByTypeConfig = { customTypeKey?: string };
+ * export type GetChildrenByTypeConfig = { customTypeKey?: string, skipWhenFound?: boolean };
  * @example
  * // Finds all occurrences of ToDo (custom component), div, and React Fragment
  * getChildrenByTypeDeep(children, ['ToDo', 'div', 'react.fragment']);
@@ -67,26 +68,28 @@ export const getChildrenByType = <T=React.ReactNode, TC=unknown>(children: T, ty
  * getChildrenByTypeDeep(children, ['ToDo'], { customTypeKey: 'myTypeKey' });
  * @docgen_note
  * This function will check the prop <em>{customTypeKey}</em> first and then <em>component.type</em> to match core html (JSX intrinsic) elements or component functions. To find a React Fragment, search for <em>'react.fragment'</em>.
+ * To stop the depth search when something was found, set <em>skipWhenFound</em> true.
  * @docgen_import { getChildrenByTypeDeep, GetChildrenByTypeConfig }
  * @docgen_imp_note <em>GetChildrenByTypeConfig</em> is a TypeScript type and is only for (optional) use with TypeScript projects
  */
-export const getChildrenByTypeDeep = <T=React.ReactNode, TC=unknown>(children: T, types: TC | Array<TC>, { customTypeKey = '__TYPE' }: GetChildrenByTypeConfig = {}) : T[] => {
+export const getChildrenByTypeDeep = <T=React.ReactNode, TC=unknown>(children: T, types: TC | Array<TC>, { customTypeKey = '__TYPE', skipWhenFound = false }: GetChildrenByTypeConfig = {}) : T[] => {
   const _children = toChildrenArray(children);
   const _types = processTypes(Array.isArray(types) ? types : [types]);
 
   let output = [];
 
   for (const child of _children) {
-    if (_types.indexOf(typeOfComponent(child, customTypeKey)) !== -1) {
+    const found = _types.indexOf(typeOfComponent(child, customTypeKey)) !== -1;
+    if (found) {
       output = [...output, child as T];
-    } 
-    
-    if ((child as NannyNode).props?.children) {
-      output = [...output, ...getChildrenByTypeDeep<T>((child as NannyNode).props.children, _types, { customTypeKey })];
+    }
+
+    if ((child as NannyNode).props?.children && !(skipWhenFound && found)) {
+      output = [...output, ...getChildrenByTypeDeep<T>((child as NannyNode).props.children, _types, { customTypeKey, skipWhenFound })];
     }
   }
 
   return output;
 };
 
-export type GetChildrenByTypeConfig = { customTypeKey?: string };
+export type GetChildrenByTypeConfig = { customTypeKey?: string, skipWhenFound?: boolean };


### PR DESCRIPTION
Hi!

I had trouble using this lib when trying out getChildrenByTypeDeep, with my nested custom components.

The behaviour I wanted was fetching `CustomComponentGroup` or `CustomComponent` but not go any deeper in the search tree when a match is found. The current behaviour would return me all 5 matches, while it would like to tweak the searching behaviour so it won't return any `CustomComponents` found inside the `CustomComponentGroup`. This is illustrated in the updated test cases.

To solve this, i added a custom parameter `skipWhenFound` (by default false), that will skip the search if something was found. This way the old behaviour is intact, but the option exist to turn on the new feature.

Added test cases to the getChildrenByTypeDeep file showing this would be a non breaking change. Any comments always welcome ;)



