### PR TITLE
fix: add null check before accessing props

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,97 +163,97 @@ CHANGELOG.md -- history of changes to the module
 README.md -- this file
 /lib
   └───/es5
+    └───/_private
+      └───utils.d.ts - 60 Bytes
+      └───utils.js - 890 Bytes
     └───/getChild
-      └───index.d.ts - 1.23 KB
-      └───index.js - 1.81 KB
+      └───index.d.ts - 1.2 KB
+      └───index.js - 1.82 KB
     └───/getChildByType
-      └───index.d.ts - 4.16 KB
-      └───index.js - 6.08 KB
+      └───index.d.ts - 4.09 KB
+      └───index.js - 5.97 KB
     └───/getChildren
-      └───index.d.ts - 1.21 KB
+      └───index.d.ts - 1.19 KB
       └───index.js - 2.07 KB
     └───/getChildrenByType
-      └───index.d.ts - 3.86 KB
-      └───index.js - 5.41 KB
+      └───index.d.ts - 3.8 KB
+      └───index.js - 5.36 KB
     └───/getChildrenWithDescendant
-      └───index.d.ts - 638 Bytes
-      └───index.js - 1.31 KB
+      └───index.d.ts - 626 Bytes
+      └───index.js - 1.28 KB
     └───/getChildrenWithDescendantByType
-      └───index.d.ts - 2.26 KB
-      └───index.js - 3.02 KB
+      └───index.d.ts - 2.22 KB
+      └───index.js - 2.96 KB
     └───/getDescendantDepth
-      └───index.d.ts - 1.14 KB
-      └───index.js - 2.46 KB
+      └───index.d.ts - 1.12 KB
+      └───index.js - 2.45 KB
     └───/getDescendantDepthByType
-      └───index.d.ts - 2.39 KB
-      └───index.js - 3.93 KB
-      └───index.d.ts - 1.1 KB
-      └───index.js - 4.23 KB
+      └───index.d.ts - 2.35 KB
+      └───index.js - 3.91 KB
+      └───index.d.ts - 1.08 KB
+      └───index.js - 4.19 KB
     └───/noEmptyChildren
-      └───index.d.ts - 1.75 KB
-      └───index.js - 3.43 KB
+      └───index.d.ts - 1.72 KB
+      └───index.js - 3.37 KB
     └───/overrideProps
-      └───index.d.ts - 2.72 KB
-      └───index.js - 4.66 KB
+      └───index.d.ts - 2.68 KB
+      └───index.js - 4.57 KB
     └───/removeChildren
-      └───index.d.ts - 1.22 KB
-      └───index.js - 2.57 KB
+      └───index.d.ts - 1.2 KB
+      └───index.js - 2.56 KB
     └───/removeChildrenByType
-      └───index.d.ts - 3.71 KB
-      └───index.js - 5.63 KB
+      └───index.d.ts - 3.65 KB
+      └───index.js - 5.58 KB
     └───/typeOfComponent
-      └───index.d.ts - 614 Bytes
-      └───index.js - 1.75 KB
-      └───types.d.ts - 249 Bytes
-      └───types.js - 79 Bytes
-    └───/_private
-      └───utils.d.ts - 61 Bytes
-      └───utils.js - 913 Bytes
+      └───index.d.ts - 603 Bytes
+      └───index.js - 1.72 KB
+      └───types.d.ts - 240 Bytes
+      └───types.js - 77 Bytes
   └───/es6
+    └───/_private
+      └───utils.d.ts - 60 Bytes
+      └───utils.js - 681 Bytes
     └───/getChild
-      └───index.d.ts - 1.23 KB
+      └───index.d.ts - 1.2 KB
       └───index.js - 1.63 KB
     └───/getChildByType
-      └───index.d.ts - 4.16 KB
-      └───index.js - 5.78 KB
+      └───index.d.ts - 4.09 KB
+      └───index.js - 5.68 KB
     └───/getChildren
-      └───index.d.ts - 1.21 KB
+      └───index.d.ts - 1.19 KB
       └───index.js - 1.87 KB
     └───/getChildrenByType
-      └───index.d.ts - 3.86 KB
-      └───index.js - 5.12 KB
+      └───index.d.ts - 3.8 KB
+      └───index.js - 5.08 KB
     └───/getChildrenWithDescendant
-      └───index.d.ts - 638 Bytes
-      └───index.js - 1.13 KB
+      └───index.d.ts - 626 Bytes
+      └───index.js - 1.1 KB
     └───/getChildrenWithDescendantByType
-      └───index.d.ts - 2.26 KB
-      └───index.js - 2.81 KB
+      └───index.d.ts - 2.22 KB
+      └───index.js - 2.76 KB
     └───/getDescendantDepth
-      └───index.d.ts - 1.14 KB
+      └───index.d.ts - 1.12 KB
       └───index.js - 2.3 KB
     └───/getDescendantDepthByType
-      └───index.d.ts - 2.39 KB
-      └───index.js - 3.74 KB
-      └───index.d.ts - 1.1 KB
-      └───index.js - 905 Bytes
+      └───index.d.ts - 2.35 KB
+      └───index.js - 3.72 KB
+      └───index.d.ts - 1.08 KB
+      └───index.js - 892 Bytes
     └───/noEmptyChildren
-      └───index.d.ts - 1.75 KB
-      └───index.js - 3.2 KB
+      └───index.d.ts - 1.72 KB
+      └───index.js - 3.15 KB
     └───/overrideProps
-      └───index.d.ts - 2.72 KB
-      └───index.js - 4.44 KB
+      └───index.d.ts - 2.68 KB
+      └───index.js - 4.36 KB
     └───/removeChildren
-      └───index.d.ts - 1.22 KB
-      └───index.js - 2.34 KB
+      └───index.d.ts - 1.2 KB
+      └───index.js - 2.33 KB
     └───/removeChildrenByType
-      └───index.d.ts - 3.71 KB
-      └───index.js - 5.32 KB
+      └───index.d.ts - 3.65 KB
+      └───index.js - 5.28 KB
     └───/typeOfComponent
-      └───index.d.ts - 614 Bytes
-      └───index.js - 1.6 KB
-      └───types.d.ts - 249 Bytes
-      └───types.js - 12 Bytes
-    └───/_private
-      └───utils.d.ts - 61 Bytes
-      └───utils.js - 700 Bytes
+      └───index.d.ts - 603 Bytes
+      └───index.js - 1.58 KB
+      └───types.d.ts - 240 Bytes
+      └───types.js - 11 Bytes
 ````

--- a/dist/README.md
+++ b/dist/README.md
@@ -163,97 +163,97 @@ CHANGELOG.md -- history of changes to the module
 README.md -- this file
 /lib
   └───/es5
+    └───/_private
+      └───utils.d.ts - 60 Bytes
+      └───utils.js - 890 Bytes
     └───/getChild
-      └───index.d.ts - 1.23 KB
-      └───index.js - 1.81 KB
+      └───index.d.ts - 1.2 KB
+      └───index.js - 1.82 KB
     └───/getChildByType
-      └───index.d.ts - 4.16 KB
-      └───index.js - 6.08 KB
+      └───index.d.ts - 4.09 KB
+      └───index.js - 5.97 KB
     └───/getChildren
-      └───index.d.ts - 1.21 KB
+      └───index.d.ts - 1.19 KB
       └───index.js - 2.07 KB
     └───/getChildrenByType
-      └───index.d.ts - 3.86 KB
-      └───index.js - 5.41 KB
+      └───index.d.ts - 3.8 KB
+      └───index.js - 5.36 KB
     └───/getChildrenWithDescendant
-      └───index.d.ts - 638 Bytes
-      └───index.js - 1.31 KB
+      └───index.d.ts - 626 Bytes
+      └───index.js - 1.28 KB
     └───/getChildrenWithDescendantByType
-      └───index.d.ts - 2.26 KB
-      └───index.js - 3.02 KB
+      └───index.d.ts - 2.22 KB
+      └───index.js - 2.96 KB
     └───/getDescendantDepth
-      └───index.d.ts - 1.14 KB
-      └───index.js - 2.46 KB
+      └───index.d.ts - 1.12 KB
+      └───index.js - 2.45 KB
     └───/getDescendantDepthByType
-      └───index.d.ts - 2.39 KB
-      └───index.js - 3.93 KB
-      └───index.d.ts - 1.1 KB
-      └───index.js - 4.23 KB
+      └───index.d.ts - 2.35 KB
+      └───index.js - 3.91 KB
+      └───index.d.ts - 1.08 KB
+      └───index.js - 4.19 KB
     └───/noEmptyChildren
-      └───index.d.ts - 1.75 KB
-      └───index.js - 3.43 KB
+      └───index.d.ts - 1.72 KB
+      └───index.js - 3.37 KB
     └───/overrideProps
-      └───index.d.ts - 2.72 KB
-      └───index.js - 4.66 KB
+      └───index.d.ts - 2.68 KB
+      └───index.js - 4.57 KB
     └───/removeChildren
-      └───index.d.ts - 1.22 KB
-      └───index.js - 2.57 KB
+      └───index.d.ts - 1.2 KB
+      └───index.js - 2.56 KB
     └───/removeChildrenByType
-      └───index.d.ts - 3.71 KB
-      └───index.js - 5.63 KB
+      └───index.d.ts - 3.65 KB
+      └───index.js - 5.58 KB
     └───/typeOfComponent
-      └───index.d.ts - 614 Bytes
-      └───index.js - 1.75 KB
-      └───types.d.ts - 249 Bytes
-      └───types.js - 79 Bytes
-    └───/_private
-      └───utils.d.ts - 61 Bytes
-      └───utils.js - 913 Bytes
+      └───index.d.ts - 603 Bytes
+      └───index.js - 1.72 KB
+      └───types.d.ts - 240 Bytes
+      └───types.js - 77 Bytes
   └───/es6
+    └───/_private
+      └───utils.d.ts - 60 Bytes
+      └───utils.js - 681 Bytes
     └───/getChild
-      └───index.d.ts - 1.23 KB
+      └───index.d.ts - 1.2 KB
       └───index.js - 1.63 KB
     └───/getChildByType
-      └───index.d.ts - 4.16 KB
-      └───index.js - 5.78 KB
+      └───index.d.ts - 4.09 KB
+      └───index.js - 5.68 KB
     └───/getChildren
-      └───index.d.ts - 1.21 KB
+      └───index.d.ts - 1.19 KB
       └───index.js - 1.87 KB
     └───/getChildrenByType
-      └───index.d.ts - 3.86 KB
-      └───index.js - 5.12 KB
+      └───index.d.ts - 3.8 KB
+      └───index.js - 5.08 KB
     └───/getChildrenWithDescendant
-      └───index.d.ts - 638 Bytes
-      └───index.js - 1.13 KB
+      └───index.d.ts - 626 Bytes
+      └───index.js - 1.1 KB
     └───/getChildrenWithDescendantByType
-      └───index.d.ts - 2.26 KB
-      └───index.js - 2.81 KB
+      └───index.d.ts - 2.22 KB
+      └───index.js - 2.76 KB
     └───/getDescendantDepth
-      └───index.d.ts - 1.14 KB
+      └───index.d.ts - 1.12 KB
       └───index.js - 2.3 KB
     └───/getDescendantDepthByType
-      └───index.d.ts - 2.39 KB
-      └───index.js - 3.74 KB
-      └───index.d.ts - 1.1 KB
-      └───index.js - 905 Bytes
+      └───index.d.ts - 2.35 KB
+      └───index.js - 3.72 KB
+      └───index.d.ts - 1.08 KB
+      └───index.js - 892 Bytes
     └───/noEmptyChildren
-      └───index.d.ts - 1.75 KB
-      └───index.js - 3.2 KB
+      └───index.d.ts - 1.72 KB
+      └───index.js - 3.15 KB
     └───/overrideProps
-      └───index.d.ts - 2.72 KB
-      └───index.js - 4.44 KB
+      └───index.d.ts - 2.68 KB
+      └───index.js - 4.36 KB
     └───/removeChildren
-      └───index.d.ts - 1.22 KB
-      └───index.js - 2.34 KB
+      └───index.d.ts - 1.2 KB
+      └───index.js - 2.33 KB
     └───/removeChildrenByType
-      └───index.d.ts - 3.71 KB
-      └───index.js - 5.32 KB
+      └───index.d.ts - 3.65 KB
+      └───index.js - 5.28 KB
     └───/typeOfComponent
-      └───index.d.ts - 614 Bytes
-      └───index.js - 1.6 KB
-      └───types.d.ts - 249 Bytes
-      └───types.js - 12 Bytes
-    └───/_private
-      └───utils.d.ts - 61 Bytes
-      └───utils.js - 700 Bytes
+      └───index.d.ts - 603 Bytes
+      └───index.js - 1.58 KB
+      └───types.d.ts - 240 Bytes
+      └───types.js - 11 Bytes
 ````

--- a/src/getChild/index.deep.test.js
+++ b/src/getChild/index.deep.test.js
@@ -27,7 +27,7 @@ let children = [
   { type: 'span' },
   { type: 'div' },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('getChildDeep', () => {
   test('Deep find', () => {

--- a/src/getChild/index.ts
+++ b/src/getChild/index.ts
@@ -36,7 +36,7 @@ export const getChildDeep = <T=React.ReactNode, TC=React.ReactNode>(children: T,
   for (const child of _children) {
     if (predicate(child as TC)) return child as TC;
 
-    if ((child as any).props?.children) {
+    if ((child as any)?.props?.children) {
       const result = getChildDeep<T, TC>((child as NannyNode).props.children, predicate);
 
       if (result) return result;

--- a/src/getChildByType/index.deep.test.js
+++ b/src/getChildByType/index.deep.test.js
@@ -28,7 +28,7 @@ const children = [
   { type: 'span' },
   { type: 'div' },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('getChildByTypeDeep', () => {
   test('Deep find => single', () => {

--- a/src/getChildByType/index.test.js
+++ b/src/getChildByType/index.test.js
@@ -4,7 +4,7 @@ const React = require('react');
 const { getChildByType } = require('../../dist/lib/es5/index');
 
 describe('getChildByType', () => {
-  React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+  React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
   
   test('Single', () => {
     let children = { props: { __TYPE: 'CustomComponent' }};

--- a/src/getChildren/index.deep.test.js
+++ b/src/getChildren/index.deep.test.js
@@ -26,8 +26,10 @@ const children = [
   { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
   { type: 'span' },
   { type: 'div' },
+  undefined,
+  { type: 'div', props: { children: [null, {type: 'div'}] } },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('getChildrenDeep', () => {
   test('Deep find', () => {

--- a/src/getChildren/index.ts
+++ b/src/getChildren/index.ts
@@ -40,7 +40,7 @@ export const getChildrenDeep = <T=React.ReactNode, TC=React.ReactNode>(children:
       output = [...output, child as TC];
     } 
     
-    if ((child as NannyNode).props?.children) {
+    if ((child as NannyNode)?.props?.children) {
       output = [...output, ...getChildrenDeep<T, TC>((child as NannyNode).props.children, predicate)];
     }
   }

--- a/src/getChildrenByType/index.deep.test.js
+++ b/src/getChildrenByType/index.deep.test.js
@@ -33,8 +33,10 @@ const children = [
   },
   { type: 'span' },
   { type: 'div' },
+  undefined,
+  { type: 'div', props: { children: [null, {type: 'div'}] } },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('getChildrenByTypeDeep', () => {
   test('Deep Single', () => {

--- a/src/getChildrenByType/index.ts
+++ b/src/getChildrenByType/index.ts
@@ -83,7 +83,7 @@ export const getChildrenByTypeDeep = <T=React.ReactNode, TC=unknown>(children: T
       output = [...output, child as T];
     }
 
-    if ((child as NannyNode).props?.children && !(skipWhenFound && found)) {
+    if ((child as NannyNode)?.props?.children && !(skipWhenFound && found)) {
       output = [...output, ...getChildrenByTypeDeep<T>((child as NannyNode).props.children, _types, { customTypeKey, skipWhenFound })];
     }
   }

--- a/src/getChildrenWithDescendant/index.test.js
+++ b/src/getChildrenWithDescendant/index.test.js
@@ -26,8 +26,10 @@ const children = [
   { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
   { type: 'span' },
   { type: 'div' },
+  undefined,
+  { type: 'div', props: { children: [null, {type: 'div'}] } },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('getChildrenWithDescendant', () => {
   test('Basic', () => {

--- a/src/getChildrenWithDescendantByType/index.test.js
+++ b/src/getChildrenWithDescendantByType/index.test.js
@@ -28,7 +28,7 @@ const children = [
   { type: 'span' },
   { type: 'div' },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('getChildrenWithDescendantByType', () => {
   test('Single', () => {

--- a/src/getDescendantDepth/index.test.js
+++ b/src/getDescendantDepth/index.test.js
@@ -26,8 +26,10 @@ const children = [
   { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
   { type: 'span' },
   { type: 'div' },
+  undefined,
+  { type: 'div', props: { children: [null, {type: 'div'}] } },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('getDescendantDepth', () => {
   test('Basic', () => {

--- a/src/getDescendantDepth/index.ts
+++ b/src/getDescendantDepth/index.ts
@@ -29,7 +29,7 @@ export const getDescendantDepth = <T=React.ReactNode, TC=React.ReactNode>(childr
     for (const child of _children) {
       if (predicate(child as TC)) return level + 1;
   
-      if ((child as any).props?.children) {
+      if ((child as any)?.props?.children) {
         const result = getDepth<T, TC>((child as NannyNode).props.children, predicate, level + 1);
   
         if (result > 0) return result;

--- a/src/getDescendantDepthByType/index.test.js
+++ b/src/getDescendantDepthByType/index.test.js
@@ -27,8 +27,10 @@ const children = [
   { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
   { type: 'span' },
   { type: 'div' },
+  undefined,
+  { type: 'div', props: { children: [null, {type: 'div'}] } },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('getDescendantDepthByType', () => {
   test('Single', () => {

--- a/src/getDescendantDepthByType/index.ts
+++ b/src/getDescendantDepthByType/index.ts
@@ -52,7 +52,7 @@ export const getDescendantDepthByType = <T=React.ReactNode, TC=unknown>(children
         return level + 1;
       } 
       
-      if ((child as NannyNode).props?.children) {
+      if ((child as NannyNode)?.props?.children) {
         const result = getDepth<T>((child as NannyNode).props.children, level + 1);
 
         if (result > 0) return result;

--- a/src/overrideProps/index.test.js
+++ b/src/overrideProps/index.test.js
@@ -4,7 +4,7 @@ const React = require('react');
 const { overrideProps, overridePropsDeep } = require('../../dist/lib/es5/index');
 
 describe('overrideProps', () => {
-  React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+  React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
   React.cloneElement = (x, props) => ({ ...x, props: { ...x.props, ...props }});
   
   const component = {
@@ -100,7 +100,7 @@ describe('overrideProps', () => {
 });
 
 describe('overridePropsDeep', () => {
-  React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+  React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
   React.cloneElement = (x, props) => ({ ...x, props: { ...x.props, ...props }});
   
   const children = {

--- a/src/removeChildren/index.deep.test.js
+++ b/src/removeChildren/index.deep.test.js
@@ -26,8 +26,10 @@ const children = [
   { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
   { type: 'span' },
   { type: 'div' },
+  undefined,
+  { type: 'div', props: { children: [null, {type: 'div'}] } },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('removeChildrenDeep', () => {
   test('Deep remove', () => {
@@ -52,6 +54,8 @@ describe('removeChildrenDeep', () => {
       { props: { __TYPE: 'CustomComponent', active: false, children: 'Outer child' }},
       { type: 'span' },
       { type: 'div' },
+      undefined,
+      { type: 'div', props: { children: [null, {type: 'div'}] } },
     ]);
   });
 });

--- a/src/removeChildren/index.ts
+++ b/src/removeChildren/index.ts
@@ -37,7 +37,7 @@ export const removeChildrenDeep = <T=React.ReactNode, TC=React.ReactNode>(childr
 
   for (const child of _children) {
     if (!predicate(child as TC)) {
-      if ((child as NannyNode).props?.children) {
+      if ((child as NannyNode)?.props?.children) {
         output = [
           ...output, 
           Object.assign((child as NannyNode), {

--- a/src/removeChildrenByType/index.deep.test.js
+++ b/src/removeChildrenByType/index.deep.test.js
@@ -26,8 +26,10 @@ const children = [
   { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
   { type: 'span' },
   { type: 'div' },
+  undefined,
+  { type: 'div', props: { children: [null, {type: 'div'}] } },
 ];
-React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]).filter(z => z != undefined);
+React.Children.toArray = x => (x && Array.isArray(x) ? x : [x]);
 
 describe('removeChildrenByTypeDeep', () => {
   test('Single', () => {
@@ -51,6 +53,8 @@ describe('removeChildrenByTypeDeep', () => {
       },
       { type: 'span' },
       { type: 'div' },
+      undefined,
+      { type: 'div', props: { children: [null, {type: 'div'}] } },
     ]);
   });
 
@@ -75,6 +79,8 @@ describe('removeChildrenByTypeDeep', () => {
       },
       { type: 'span' },
       { type: 'div' },
+      undefined,
+      { type: 'div', props: { children: [null, {type: 'div'}] } },
     ]);
   });
 
@@ -99,6 +105,8 @@ describe('removeChildrenByTypeDeep', () => {
       { props: { __TYPE: 'CustomComponent', active: false, children: 'Outer child' }},
       { props: { __TYPE: 'CustomComponent', active: true, children: 'Outer child active' }},
       { type: 'div' },
+      undefined,
+      { type: 'div', props: { children: [null, {type: 'div'}] } },
     ]);
   });
 
@@ -120,6 +128,8 @@ describe('removeChildrenByTypeDeep', () => {
         },
       },
       { type: 'div' },
+      undefined,
+      { type: 'div', props: { children: [null, {type: 'div'}] } },
     ]);
   });
 });

--- a/src/removeChildrenByType/index.ts
+++ b/src/removeChildrenByType/index.ts
@@ -75,7 +75,7 @@ export const removeChildrenByTypeDeep = <T=React.ReactNode, TC=unknown>(children
   for (const child of _children) {
     if (_types.indexOf(typeOfComponent(child, customTypeKey)) === -1) {
 
-      if ((child as NannyNode).props?.children) {
+      if ((child as NannyNode)?.props?.children) {
         output = [
           ...output, 
           Object.assign({}, (child as NannyNode), {


### PR DESCRIPTION
This corrects null reference error when a child is null/undefined (which is valid).

Closes 18.